### PR TITLE
flake: migrate from cachix to cache.numtide.com

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,11 +3,11 @@
 
   nixConfig = {
     extra-substituters = [
-      "https://numtide.cachix.org"
+      "https://cache.numtide.com"
       "https://nix-community.cachix.org"
     ];
     extra-trusted-public-keys = [
-      "numtide.cachix.org-1:2ps1kLBUWjxIneOy1Ik6cQjb41X0iXVXeHigGmycPPE="
+      "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
     ];
   };


### PR DESCRIPTION
Numtide is migrating from Cachix to a self-hosted binary cache at cache.numtide.com. Update the substituter URL and public key to use the new infrastructure.